### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Licensed under CC0.
 
 # OCamp subcommands
 
-## fire
+## The default operation is to start a command
 
-Just wrap a unix command with "ocamp fire" to enable the extension:
+Just wrap a unix command with "ocamp" to enable the extension:
 
-    $ ocamp fire bash
+    $ ocamp bash
 
 This will spawn a new bash session where the following subcommands are enabled.
 


### PR DESCRIPTION
The way to invoke ocamp has been changed, dropping the need to use 'fire' subcommand.
